### PR TITLE
Fix crash when quitting during credential screen

### DIFF
--- a/moneyflow/app.py
+++ b/moneyflow/app.py
@@ -761,11 +761,16 @@ class MoneyflowApp(App):
 
         finally:
             self.loading = False
-            self.query_one("#loading", LoadingIndicator).display = False
-            # DON'T hide loading-status if we had an error
-            if not has_error:
-                self.query_one("#loading-status", Static).display = False
-            # If there was an error, keep the error message visible
+            # Safely hide loading UI (may fail if app is shutting down)
+            try:
+                self.query_one("#loading", LoadingIndicator).display = False
+                # DON'T hide loading-status if we had an error
+                if not has_error:
+                    self.query_one("#loading-status", Static).display = False
+                # If there was an error, keep the error message visible
+            except Exception:
+                # DOM already torn down during shutdown - this is fine
+                pass
 
     def update_loading_progress(self, current: int, total: int, message: str) -> None:
         """Update loading progress message."""


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when the user quits (Ctrl+C or 'q') during the credential unlock screen.

## Problem

When quitting during initialization, the app tries to clean up UI elements in the `finally` block, but the DOM has already been torn down, causing a `NoMatches` exception.

## Solution

Wrap DOM queries in the `finally` block with try-except to handle graceful shutdown when the DOM is no longer available.

## Testing

1. Run `moneyflow`
2. When credential screen appears, press 'q' or Ctrl+C
3. App should exit cleanly without stack trace