### PR TITLE
Avoid clobbering production config.yaml when running test suite

### DIFF
--- a/moneyflow/app.py
+++ b/moneyflow/app.py
@@ -275,9 +275,10 @@ class MoneyflowApp(App):
         """Initialize data manager, cache manager, and controller."""
         # In demo mode, use a temp directory for merchant cache (don't pollute ~/.moneyflow)
         merchant_cache_dir = "" if not self.demo_mode else "/tmp/moneyflow_demo"
-        # config_dir is already a string (or None), DataManager accepts Optional[str]
+        # config_dir is required - default to ~/.moneyflow if not specified
+        config_dir = self.config_dir if self.config_dir else str(Path.home() / ".moneyflow")
         self.data_manager = DataManager(
-            self.backend, merchant_cache_dir=merchant_cache_dir, config_dir=self.config_dir
+            self.backend, config_dir=config_dir, merchant_cache_dir=merchant_cache_dir
         )
 
         # Initialize cache manager only if user requested caching
@@ -499,7 +500,9 @@ class MoneyflowApp(App):
             result = self.cache_manager.load_cache()
             if result:
                 df, categories, category_groups, metadata = result
+
                 # Apply category grouping dynamically (so CATEGORY_GROUPS changes take effect)
+                # Note: DataManager.__init__() already loaded config.yaml and built the mapping
                 loading_status.update("🔄 Applying category groupings...")
                 df = self.data_manager.apply_category_groups(df)
 

--- a/moneyflow/data_manager.py
+++ b/moneyflow/data_manager.py
@@ -75,16 +75,14 @@ class DataManager:
 
     MERCHANT_CACHE_MAX_AGE_HOURS = 24  # Refresh once per day
 
-    def __init__(
-        self, mm: FinanceBackend, merchant_cache_dir: str = "", config_dir: Optional[str] = None
-    ):
+    def __init__(self, mm: FinanceBackend, config_dir: str, merchant_cache_dir: str = ""):
         """
         Initialize DataManager with a finance backend.
 
         Args:
             mm: Backend instance (must implement FinanceBackend interface)
-            merchant_cache_dir: Directory for merchant cache (defaults to ~/.moneyflow/)
-            config_dir: Optional config directory for config.yaml (defaults to ~/.moneyflow/)
+            config_dir: Config directory for config.yaml (required to prevent accidental pollution)
+            merchant_cache_dir: Directory for merchant cache (defaults to config_dir if empty)
         """
         self.mm = mm
         self.config_dir = config_dir  # Store for apply_category_groups
@@ -239,7 +237,7 @@ class DataManager:
             - category_groups: Dict mapping group_id to {name, type, ...}
 
         Example:
-            >>> dm = DataManager(backend)
+            >>> dm = DataManager(backend, config_dir="~/.moneyflow")
             >>> df, cats, groups = await dm.fetch_all_data(
             ...     start_date="2025-01-01",
             ...     progress_callback=lambda msg: print(msg)

--- a/tests/test_app_controller.py
+++ b/tests/test_app_controller.py
@@ -27,10 +27,11 @@ def mock_view():
 
 
 @pytest.fixture
-async def controller(mock_view, mock_mm):
-    """Provide controller with mock dependencies."""
+async def controller(mock_view, mock_mm, tmp_path):
+    """Provide controller with mock dependencies and isolated config."""
     await mock_mm.login()
-    data_manager = DataManager(mock_mm)
+    # Use tmp_path for config_dir to avoid modifying user's ~/.moneyflow/config.yaml
+    data_manager = DataManager(mock_mm, config_dir=str(tmp_path))
     state = AppState()
 
     # Fetch data

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -55,9 +55,9 @@ class TestAggregation:
         # Note: Sorting is now handled by app.py, not by aggregate methods
         # The aggregation just returns grouped data
 
-    async def test_aggregate_by_merchant_top_category_single(self, mock_mm):
+    async def test_aggregate_by_merchant_top_category_single(self, mock_mm, tmp_path):
         """Test top category when all transactions have same category."""
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         # All Whole Foods transactions are Groceries
         df = pl.DataFrame(
@@ -80,9 +80,9 @@ class TestAggregation:
         assert row["top_category"] == "Groceries"
         assert row["top_category_pct"] == 100  # 100% are Groceries
 
-    async def test_aggregate_by_merchant_top_category_mixed(self, mock_mm):
+    async def test_aggregate_by_merchant_top_category_mixed(self, mock_mm, tmp_path):
         """Test top category when transactions have different categories."""
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         # Starbucks: 7 Coffee Shops, 3 Groceries
         df = pl.DataFrame(
@@ -105,9 +105,9 @@ class TestAggregation:
         assert row["top_category"] == "Coffee Shops"
         assert row["top_category_pct"] == 70  # 7/10 = 70%
 
-    async def test_aggregate_by_merchant_top_category_multiple_merchants(self, mock_mm):
+    async def test_aggregate_by_merchant_top_category_multiple_merchants(self, mock_mm, tmp_path):
         """Test top category with multiple merchants."""
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         df = pl.DataFrame(
             {
@@ -736,7 +736,7 @@ class TestFetchTransactionsPagination:
         for txn in transactions:
             assert "2024-10-02" <= txn["date"] <= "2024-10-03"
 
-    async def test_fetch_alternative_results_format(self, mock_mm):
+    async def test_fetch_alternative_results_format(self, mock_mm, tmp_path):
         """Test fetching with alternative results format (bare 'results' key)."""
         # Temporarily change mock to return bare 'results' format
         original_get_transactions = mock_mm.get_transactions
@@ -751,26 +751,26 @@ class TestFetchTransactionsPagination:
         mock_mm.get_transactions = alternate_format_get_transactions
 
         await mock_mm.login()
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         transactions = await dm._fetch_all_transactions()
 
         assert len(transactions) > 0
         assert len(transactions) == 6  # All mock transactions
 
-    async def test_fetch_empty_results(self, mock_mm):
+    async def test_fetch_empty_results(self, mock_mm, tmp_path):
         """Test fetching when API returns empty results."""
         # Clear all transactions
         mock_mm.transactions = []
 
         await mock_mm.login()
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         transactions = await dm._fetch_all_transactions()
 
         assert len(transactions) == 0
 
-    async def test_fetch_progress_without_total_count(self, mock_mm):
+    async def test_fetch_progress_without_total_count(self, mock_mm, tmp_path):
         """Test progress callback when total count is not available."""
         # Modify mock to not include totalCount
         original_get_transactions = mock_mm.get_transactions
@@ -785,7 +785,7 @@ class TestFetchTransactionsPagination:
         mock_mm.get_transactions = no_total_count_get_transactions
 
         await mock_mm.login()
-        dm = DataManager(mock_mm)
+        dm = DataManager(mock_mm, config_dir=str(tmp_path))
 
         progress_messages = []
 
@@ -915,6 +915,77 @@ class TestCategoryMappingRefresh:
             groups = gas_txns["group"].unique().to_list()
             assert "Auto & Transport" in groups
             assert "Wrong Group" not in groups
+
+    async def test_category_mapping_correct_after_restart_with_cache(self, mock_mm, tmp_path):
+        """
+        Test that categories work correctly when loading from cache after app restart.
+
+        Regression test for bug where transfers would appear when loading from cache.
+        The root cause was that tests were corrupting the user's config.yaml by
+        not using isolated config directories.
+
+        This test verifies:
+        1. fetch_all_data() updates config.yaml with fresh categories from API
+        2. After app restart, DataManager.__init__() loads updated config.yaml
+        3. apply_category_groups() works correctly with the mapping from config.yaml
+        """
+        import yaml
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+
+        # Scenario: config.yaml starts with incomplete categories (before first API fetch)
+        initial_config = {
+            "version": 1,
+            "fetched_categories": {
+                "Food & Dining": ["Groceries", "Restaurants"],
+                "Shopping": ["Clothing"],
+                # NOTE: Missing "Auto & Transport" group with "Gas" category
+            },
+        }
+
+        with open(config_path, "w") as f:
+            yaml.dump(initial_config, f)
+
+        # Login to mock backend
+        await mock_mm.login()
+
+        # Initialize DataManager (loads incomplete categories from config.yaml)
+        dm = DataManager(mock_mm, config_dir=str(config_dir))
+
+        # Verify initial mapping is incomplete (missing Auto & Transport)
+        initial_mapping = dm.category_to_group
+        assert initial_mapping.get("Gas") is None  # Not in mapping
+
+        # Fetch data from API (saves fresh categories to config.yaml)
+        df_from_api, _, _ = await dm.fetch_all_data()
+
+        # Verify fresh categories were saved to config.yaml
+        with open(config_path, "r") as f:
+            saved_config = yaml.safe_load(f)
+        assert len(saved_config["fetched_categories"]) == 3  # Now has all 3 groups
+
+        # Verify mapping was rebuilt by fetch_all_data()
+        assert dm.category_to_group.get("Gas") == "Auto & Transport"
+
+        # ========== SIMULATE APP RESTART WITH CACHE ==========
+
+        # Simulate app restart: Create NEW DataManager instance (like when app restarts)
+        dm_after_restart = DataManager(mock_mm, config_dir=str(config_dir))
+
+        # DataManager.__init__() should load the UPDATED config.yaml
+        # This is the KEY FIX: config.yaml must be protected from test corruption
+        assert dm_after_restart.category_to_group.get("Gas") == "Auto & Transport"
+
+        # Apply category groups (simulates what app.py does when loading from cache)
+        df_from_cache = df_from_api.clone()  # Simulate cached DataFrame
+        df_with_groups = dm_after_restart.apply_category_groups(df_from_cache)
+
+        # Verify Gas transactions have correct group
+        gas_txns = df_with_groups.filter(df_with_groups["category"] == "Gas")
+        if len(gas_txns) > 0:
+            assert gas_txns["group"].unique().to_list()[0] == "Auto & Transport"
 
 
 class TestTimeAggregation:

--- a/tests/test_edit_orchestration.py
+++ b/tests/test_edit_orchestration.py
@@ -17,10 +17,11 @@ from .mock_view import MockViewPresenter
 
 
 @pytest.fixture
-async def edit_controller(mock_mm):
-    """Provide controller with edit-specific setup."""
+async def edit_controller(mock_mm, tmp_path):
+    """Provide controller with edit-specific setup and isolated config."""
     await mock_mm.login()
-    data_manager = DataManager(mock_mm)
+    # Use tmp_path for config_dir to avoid modifying user's ~/.moneyflow/config.yaml
+    data_manager = DataManager(mock_mm, config_dir=str(tmp_path))
     state = AppState()
 
     # Fetch data

--- a/tests/test_merchant_cache.py
+++ b/tests/test_merchant_cache.py
@@ -20,10 +20,11 @@ def temp_merchant_cache_dir(tmp_path):
 
 
 @pytest.fixture
-async def data_manager_with_cache(mock_mm, temp_merchant_cache_dir):
-    """Provide DataManager with temporary merchant cache."""
+async def data_manager_with_cache(mock_mm, temp_merchant_cache_dir, tmp_path):
+    """Provide DataManager with temporary merchant cache and isolated config."""
     await mock_mm.login()
-    dm = DataManager(mock_mm, merchant_cache_dir=temp_merchant_cache_dir)
+    # Use tmp_path for config_dir to avoid modifying user's ~/.moneyflow/config.yaml
+    dm = DataManager(mock_mm, config_dir=str(tmp_path), merchant_cache_dir=temp_merchant_cache_dir)
     return dm
 
 


### PR DESCRIPTION
This also verifies that the category mapping is applied correctly when loading the cached data (the original bug I was investigating)