### PR TITLE
fix: NotificationSeverity crash on Python 3.11 + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 5

--- a/moneyflow/tui/view_interface.py
+++ b/moneyflow/tui/view_interface.py
@@ -21,6 +21,9 @@ class NotificationSeverity(str, Enum):
     WARNING = "warning"
     ERROR = "error"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class TableColumn(TypedDict):
     label: str

--- a/tests/test_notification_helper.py
+++ b/tests/test_notification_helper.py
@@ -8,6 +8,7 @@ and return the correct severity/timeout values.
 import pytest
 
 from moneyflow.tui import notification_helper
+from moneyflow.tui.view_interface import NotificationSeverity
 
 
 class TestCommitNotifications:
@@ -322,3 +323,36 @@ class TestMessageQuality:
         assert any(key in msg for key in ["Press", "w", "Ctrl"]), (
             f"Action message doesn't mention key: {msg}"
         )
+
+
+class TestNotificationSeverityStr:
+    """Verify str() returns the value, not the enum member name.
+
+    Python 3.11 changed str(Enum) to return 'ClassName.MEMBER' instead
+    of the value for (str, Enum) subclasses. Textual uses f-strings on
+    severity to build CSS class names, so dots in the string cause a
+    BadIdentifier crash.
+    """
+
+    @pytest.mark.parametrize(
+        "member,expected",
+        [
+            (NotificationSeverity.INFO, "information"),
+            (NotificationSeverity.WARNING, "warning"),
+            (NotificationSeverity.ERROR, "error"),
+        ],
+    )
+    def test_str_returns_value(self, member, expected):
+        assert str(member) == expected
+
+    @pytest.mark.parametrize(
+        "member,expected",
+        [
+            (NotificationSeverity.INFO, "-information"),
+            (NotificationSeverity.WARNING, "-warning"),
+            (NotificationSeverity.ERROR, "-error"),
+        ],
+    )
+    def test_fstring_returns_value(self, member, expected):
+        """f-string formatting must produce valid CSS class names."""
+        assert f"-{member}" == expected


### PR DESCRIPTION
## Summary

- **Fix toast crash**: `NotificationSeverity(str, Enum).__str__()` returns `NotificationSeverity.INFO` on Python 3.11 instead of `information`. Textual uses `f"-{severity}"` for CSS class names, so the dot triggers `BadIdentifier`. Added `__str__` returning `self.value`.
- **Add Dependabot**: Weekly checks for pip and GitHub Actions dependencies so version drift gets caught earlier.

## Test plan

- [x] New tests verify `str()` and f-string formatting return plain values for all severity levels
- [x] All 51 notification helper tests pass
- [x] Pre-commit hooks pass (ruff, pyright, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)