### PR TITLE
deps: Bump ynab from 1.9.0 to 4.1.0 (with 4.x API fixes)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,12 @@
 
         ynab = pythonPackages.buildPythonPackage rec {
           pname = "ynab";
-          version = "1.9.0";
+          version = "4.1.0";
           format = "wheel";
 
           src = pkgs.fetchurl {
-            url = "https://files.pythonhosted.org/packages/b2/9c/0ccd11bcdf7522fcb2823fcd7ffbb48e3164d72caaf3f920c7b068347175/ynab-1.9.0-py3-none-any.whl";
-            hash = "sha256-cqwCGWBbQoAUloTs0P7DvXXZOHctZc3uqbPmahsvRw0=";
+            url = "https://files.pythonhosted.org/packages/d8/8f/96b9f962cca0cbea056d8c0304fd0d2021fa0a42627835ed9a98bdcbab95/ynab-4.1.0-py3-none-any.whl";
+            hash = "sha256-hyp+zxm4Ksln3oaxpxrzdgsy6+x7a/I4345VD6RE2/0=";
           };
 
           dependencies = with pythonPackages; [

--- a/moneyflow/backends/ynab_client.py
+++ b/moneyflow/backends/ynab_client.py
@@ -290,7 +290,11 @@ class YNABClient:
                 update_data.payee_name = merchant_name
 
         if category_id is not None:
-            update_data.category_id = uuid.UUID(category_id)
+            # _convert_transaction emits "uncategorized" as a placeholder for
+            # transactions with no category, so the app may round-trip it back here.
+            update_data.category_id = (
+                None if category_id == "uncategorized" else uuid.UUID(category_id)
+            )
 
         # Note: YNAB API doesn't support setting deleted via update
         # The deleted field is read-only. To "hide" transactions,

--- a/moneyflow/backends/ynab_client.py
+++ b/moneyflow/backends/ynab_client.py
@@ -5,6 +5,7 @@ Wraps the ynab-python SDK to provide a cleaner interface and handle
 YNAB-specific data transformations (milliunits, transfers, etc.).
 """
 
+import uuid
 from typing import Any, Dict, List, Optional
 
 import ynab
@@ -71,10 +72,10 @@ class YNABClient:
         configuration = ynab.Configuration(access_token=self.access_token)
         self.api_client = ynab.ApiClient(configuration)
 
-        budgets_api = ynab.BudgetsApi(self.api_client)
-        budgets_response = budgets_api.get_budgets()
+        plans_api = ynab.PlansApi(self.api_client)
+        plans_response = plans_api.get_plans()
 
-        self._resolve_budget_id(budgets_response, budget_id)
+        self._resolve_budget_id(plans_response, budget_id)
 
         # Clear budget-dependent caches on re-login
         self._invalidate_cache()
@@ -82,24 +83,24 @@ class YNABClient:
         # Fetch and cache account information (including on_budget status)
         self._fetch_and_cache_accounts()
 
-    def _resolve_budget_id(self, budgets_response: Any, requested_id: Optional[str]) -> None:
-        if not budgets_response.data.budgets:
+    def _resolve_budget_id(self, plans_response: Any, requested_id: Optional[str]) -> None:
+        if not plans_response.data.plans:
             raise ValueError("No budgets found in YNAB account")
 
         if requested_id:
             # Verify the specified budget exists
-            budget = next((b for b in budgets_response.data.budgets if b.id == requested_id), None)
+            budget = next((b for b in plans_response.data.plans if str(b.id) == requested_id), None)
             if not budget:
                 raise ValueError(f"Budget with ID '{requested_id}' not found")
             self.budget_id = requested_id
         elif not self.budget_id:
             # Use first budget if no budget specified
-            budget = budgets_response.data.budgets[0]
-            self.budget_id = budget.id
+            budget = plans_response.data.plans[0]
+            self.budget_id = str(budget.id)
         else:
             # Use existing budget_id
             budget = next(
-                (b for b in budgets_response.data.budgets if b.id == self.budget_id), None
+                (b for b in plans_response.data.plans if str(b.id) == self.budget_id), None
             )
 
         # Fetch currency symbol from budget settings
@@ -119,12 +120,12 @@ class YNABClient:
         if not self.api_client:
             raise ValueError("Must authenticate first")
 
-        budgets_api = ynab.BudgetsApi(self.api_client)
-        budgets_response = budgets_api.get_budgets()
+        plans_api = ynab.PlansApi(self.api_client)
+        plans_response = plans_api.get_plans()
 
         return [
             {
-                "id": budget.id,
+                "id": str(budget.id),
                 "name": budget.name,
                 "last_modified_on": str(budget.last_modified_on)
                 if budget.last_modified_on
@@ -135,7 +136,7 @@ class YNABClient:
                     else "$"
                 },
             }
-            for budget in budgets_response.data.budgets
+            for budget in plans_response.data.plans
         ]
 
     def get_transactions(
@@ -169,10 +170,10 @@ class YNABClient:
         if self._transaction_cache is None or self._cache_params != cache_key:
             if start_date:
                 response = self._transactions_api.get_transactions(
-                    budget_id=self.budget_id, since_date=start_date
+                    plan_id=self.budget_id, since_date=start_date
                 )
             else:
-                response = self._transactions_api.get_transactions(budget_id=self.budget_id)
+                response = self._transactions_api.get_transactions(plan_id=self.budget_id)
 
             self._transaction_cache = [
                 self._convert_transaction(txn) for txn in response.data.transactions
@@ -192,7 +193,7 @@ class YNABClient:
 
     def _fetch_categories(self) -> None:
         if self._category_cache is None:
-            response = self._categories_api.get_categories(budget_id=self.budget_id)
+            response = self._categories_api.get_categories(plan_id=self.budget_id)
             self._category_cache = response.data
 
     def get_transaction_categories(self) -> Dict[str, Any]:
@@ -210,10 +211,10 @@ class YNABClient:
             for category in category_group.categories:
                 categories.append(
                     {
-                        "id": category.id,
+                        "id": str(category.id),
                         "name": category.name,
                         "group": {
-                            "id": category_group.id,
+                            "id": str(category_group.id),
                             "name": category_group.name,
                             "type": "expense",
                         },
@@ -234,7 +235,7 @@ class YNABClient:
 
         category_groups = [
             {
-                "id": group.id,
+                "id": str(group.id),
                 "name": group.name,
                 "type": "expense",
             }
@@ -267,7 +268,7 @@ class YNABClient:
         self._ensure_authenticated()
 
         txn_response = self._transactions_api.get_transaction_by_id(
-            budget_id=self.budget_id, transaction_id=transaction_id
+            plan_id=self.budget_id, transaction_id=transaction_id
         )
         existing_txn = txn_response.data.transaction
 
@@ -289,14 +290,14 @@ class YNABClient:
                 update_data.payee_name = merchant_name
 
         if category_id is not None:
-            update_data.category_id = category_id
+            update_data.category_id = uuid.UUID(category_id)
 
         # Note: YNAB API doesn't support setting deleted via update
         # The deleted field is read-only. To "hide" transactions,
         # we would need to actually delete them, which we avoid here.
 
         updated = self._transactions_api.update_transaction(
-            budget_id=self.budget_id,
+            plan_id=self.budget_id,
             transaction_id=transaction_id,
             data=ynab.PutTransactionWrapper(transaction=update_data),
         )
@@ -319,7 +320,7 @@ class YNABClient:
 
         try:
             self._transactions_api.delete_transaction(
-                budget_id=self.budget_id, transaction_id=transaction_id
+                plan_id=self.budget_id, transaction_id=transaction_id
             )
             self._invalidate_cache()
             return True
@@ -335,7 +336,7 @@ class YNABClient:
         """
         self._ensure_authenticated()
 
-        response = self._payees_api.get_payees(budget_id=self.budget_id)
+        response = self._payees_api.get_payees(plan_id=self.budget_id)
 
         return sorted(payee.name for payee in response.data.payees)
 
@@ -373,7 +374,7 @@ class YNABClient:
 
             # Call the PATCH /payees/{payee_id} endpoint
             response = self._payees_api.update_payee(
-                budget_id=self.budget_id, payee_id=payee_id, data=wrapper
+                plan_id=self.budget_id, payee_id=payee_id, data=wrapper
             )
 
             logger.info(
@@ -504,35 +505,36 @@ class YNABClient:
                 f"Using batch transaction update to reassign from {old_payee.id} to {target_payee.id}."
             )
             return self._batch_reassign_transactions(
-                old_payee_id=old_payee.id,
-                target_payee_id=target_payee.id,
+                old_payee_id=str(old_payee.id),
+                target_payee_id=str(target_payee.id),
                 old_merchant_name=old_merchant_name,
                 new_merchant_name=new_merchant_name,
             )
 
         # Target payee doesn't exist - update the payee name (cascades to all transactions)
-        success = self.update_payee(old_payee.id, new_merchant_name)
+        old_payee_id_str = str(old_payee.id)
+        success = self.update_payee(old_payee_id_str, new_merchant_name)
 
         if success:
             logger.info(
-                f"Successfully batch-updated payee {old_payee.id}: "
+                f"Successfully batch-updated payee {old_payee_id_str}: "
                 f"'{old_merchant_name}' -> '{new_merchant_name}'"
             )
             return {
                 "success": True,
-                "payee_id": old_payee.id,
+                "payee_id": old_payee_id_str,
                 "transactions_affected": -1,  # YNAB doesn't provide this count
                 "method": "payee_update",
-                "message": f"Updated payee {old_payee.id} from '{old_merchant_name}' to '{new_merchant_name}'",
+                "message": f"Updated payee {old_payee_id_str} from '{old_merchant_name}' to '{new_merchant_name}'",
             }
         else:
-            logger.error(f"Failed to update payee {old_payee.id}")
+            logger.error(f"Failed to update payee {old_payee_id_str}")
             return {
                 "success": False,
-                "payee_id": old_payee.id,
+                "payee_id": old_payee_id_str,
                 "transactions_affected": 0,
                 "method": "payee_update_failed",
-                "message": f"Failed to update payee {old_payee.id}",
+                "message": f"Failed to update payee {old_payee_id_str}",
             }
 
     def get_transaction_count_by_payee(self, payee_name: str) -> int:
@@ -555,7 +557,7 @@ class YNABClient:
             return 0
 
         response = self._transactions_api.get_transactions_by_payee(
-            budget_id=self.budget_id, payee_id=payee_result["payee"].id
+            plan_id=self.budget_id, payee_id=str(payee_result["payee"].id)
         )
         return len(response.data.transactions)
 
@@ -617,7 +619,7 @@ class YNABClient:
         try:
             # Get all transactions for the old payee
             response = self._transactions_api.get_transactions_by_payee(
-                budget_id=self.budget_id, payee_id=old_payee_id
+                plan_id=self.budget_id, payee_id=old_payee_id
             )
             transactions = response.data.transactions
 
@@ -643,7 +645,7 @@ class YNABClient:
 
             # Execute batch update
             wrapper = ynab.PatchTransactionsWrapper(transactions=update_list)
-            self._transactions_api.update_transactions(budget_id=self.budget_id, data=wrapper)
+            self._transactions_api.update_transactions(plan_id=self.budget_id, data=wrapper)
 
             self._invalidate_cache()
 
@@ -696,11 +698,11 @@ class YNABClient:
         """
         self._ensure_authenticated()
 
-        response = self._accounts_api.get_accounts(budget_id=self.budget_id)
+        response = self._accounts_api.get_accounts(plan_id=self.budget_id)
 
         self._account_cache = {
-            account.id: {
-                "id": account.id,
+            str(account.id): {
+                "id": str(account.id),
                 "name": account.name,
                 "on_budget": account.on_budget,
                 "closed": account.closed,
@@ -731,24 +733,25 @@ class YNABClient:
             Dictionary in moneyflow format
         """
         # Check if transaction belongs to a tracking account
+        account_id_str = str(txn.account_id) if txn.account_id else None
         is_tracking_account = False
-        if self._account_cache and txn.account_id in self._account_cache:
-            is_tracking_account = not self._account_cache[txn.account_id]["on_budget"]
+        if self._account_cache and account_id_str and account_id_str in self._account_cache:
+            is_tracking_account = not self._account_cache[account_id_str]["on_budget"]
 
         return {
             "id": txn.id,
             "date": str(txn.var_date),
             "amount": float(txn.amount) / 1000.0,
             "merchant": {
-                "id": txn.payee_id or "unknown",
+                "id": str(txn.payee_id) if txn.payee_id else "unknown",
                 "name": txn.payee_name or "Unknown",
             },
             "category": {
-                "id": txn.category_id or "uncategorized",
+                "id": str(txn.category_id) if txn.category_id else "uncategorized",
                 "name": txn.category_name or "Uncategorized",
             },
             "account": {
-                "id": txn.account_id,
+                "id": account_id_str,
                 "displayName": txn.account_name,
             },
             "notes": txn.memo or "",
@@ -761,7 +764,7 @@ class YNABClient:
 
     def _fetch_and_cache_payees(self) -> None:
         if self._payee_cache is None:
-            response = self._payees_api.get_payees(budget_id=self.budget_id)
+            response = self._payees_api.get_payees(plan_id=self.budget_id)
             self._payee_cache = response.data.payees
 
     def _find_payees_by_name(self, merchant_name: str) -> Dict[str, Any]:
@@ -793,7 +796,7 @@ class YNABClient:
 
         # Detect duplicates
         duplicates_found = len(matching_payees) > 1
-        duplicate_ids = [p.id for p in matching_payees] if duplicates_found else []
+        duplicate_ids = [str(p.id) for p in matching_payees] if duplicates_found else []
 
         if duplicates_found:
             logger.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "textual>=0.47.0",
     "cryptography>=41.0.0",
     "python-dateutil>=2.8.0",
-    "ynab>=1.9.0",
+    "ynab>=4.1.0",
     "mcp[cli]>=1.25.0",
 ]
 

--- a/tests/test_ynab_backend.py
+++ b/tests/test_ynab_backend.py
@@ -163,6 +163,45 @@ class TestYNABBackend:
         assert result["updateTransaction"]["transaction"]["id"] == "txn-1"
 
     @pytest.mark.asyncio
+    async def test_update_transaction_uncategorized_placeholder(self, backend, mock_ynab_api):
+        """_convert_transaction emits 'uncategorized' for transactions with no
+        category, so update_transaction must treat it as None rather than
+        attempting uuid.UUID('uncategorized')."""
+        backend.client.budget_id = "test-budget-id"
+        backend.client.api_client = MagicMock()
+
+        mock_existing_txn = MagicMock()
+        mock_existing_txn.account_id = "acc-1"
+        mock_existing_txn.var_date = "2025-01-15"
+        mock_existing_txn.amount = -50000
+
+        mock_get_response = MagicMock()
+        mock_get_response.data.transaction = mock_existing_txn
+
+        mock_updated_txn = MagicMock()
+        mock_updated_txn.id = "txn-1"
+
+        mock_update_response = MagicMock()
+        mock_update_response.data.transaction = mock_updated_txn
+
+        mock_transactions_api = MagicMock()
+        mock_transactions_api.get_transaction_by_id.return_value = mock_get_response
+        mock_transactions_api.update_transaction.return_value = mock_update_response
+
+        mock_ynab_api.TransactionsApi.return_value = mock_transactions_api
+
+        # Should not raise ValueError
+        result = await backend.update_transaction(
+            transaction_id="txn-1", category_id="uncategorized"
+        )
+
+        assert result["updateTransaction"]["transaction"]["id"] == "txn-1"
+        # Verify the update_data passed to PutTransactionWrapper had category_id=None
+        # (the mock receives the actual update_data MagicMock as a kwarg)
+        wrapper_call = mock_ynab_api.PutTransactionWrapper.call_args
+        assert wrapper_call[1]["transaction"].category_id is None
+
+    @pytest.mark.asyncio
     async def test_delete_transaction_success(self, backend, mock_ynab_api):
         backend.client.budget_id = "test-budget-id"
         backend.client.api_client = MagicMock()

--- a/tests/test_ynab_backend.py
+++ b/tests/test_ynab_backend.py
@@ -21,13 +21,13 @@ class TestYNABBackend:
         mock_budget.id = "test-budget-id"
         mock_budget.name = "Test Budget"
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
 
         await backend.login(password="test-access-token")
 
@@ -41,13 +41,13 @@ class TestYNABBackend:
 
     @pytest.mark.asyncio
     async def test_login_no_budgets(self, backend, mock_ynab_api):
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = []
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = []
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
 
         with pytest.raises(ValueError, match="No budgets found"):
             await backend.login(password="test-access-token")
@@ -155,7 +155,9 @@ class TestYNABBackend:
         mock_ynab_api.PayeesApi.return_value = mock_payees_api
 
         result = await backend.update_transaction(
-            transaction_id="txn-1", merchant_name="New Merchant", category_id="cat-2"
+            transaction_id="txn-1",
+            merchant_name="New Merchant",
+            category_id="00000000-0000-0000-0000-000000000002",
         )
 
         assert result["updateTransaction"]["transaction"]["id"] == "txn-1"
@@ -351,7 +353,7 @@ class TestYNABBackend:
         assert result is True
         mock_payees_api.update_payee.assert_called_once()
         call_args = mock_payees_api.update_payee.call_args
-        assert call_args[1]["budget_id"] == "test-budget-id"
+        assert call_args[1]["plan_id"] == "test-budget-id"
         assert call_args[1]["payee_id"] == "payee-123"
 
     def test_update_payee_invalid_name_empty(self, backend):
@@ -543,7 +545,7 @@ class TestYNABBackend:
 
         # Verify batch transaction update was called
         mock_transactions_api.get_transactions_by_payee.assert_called_once_with(
-            budget_id="test-budget-id", payee_id="payee-old"
+            plan_id="test-budget-id", payee_id="payee-old"
         )
         mock_transactions_api.update_transactions.assert_called_once()
 
@@ -663,7 +665,7 @@ class TestYNABBackend:
         # Verify payee was updated (in real API, this cascades to all transactions)
         mock_payees_api.update_payee.assert_called_once()
         call_args = mock_payees_api.update_payee.call_args
-        assert call_args[1]["budget_id"] == "test-budget-id"
+        assert call_args[1]["plan_id"] == "test-budget-id"
         assert call_args[1]["payee_id"] == "payee-amazon-old"
 
         # Verify cache was invalidated (so next fetch gets updated data)
@@ -766,11 +768,11 @@ class TestYNABBackend:
         mock_budget.name = "Test Budget"
         mock_budget.currency_format = None
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
         # Mock accounts
         mock_checking = MagicMock()
@@ -793,7 +795,7 @@ class TestYNABBackend:
         mock_accounts_api = MagicMock()
         mock_accounts_api.get_accounts.return_value = mock_accounts_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
         mock_ynab_api.AccountsApi.return_value = mock_accounts_api
 
         await backend.login(password="test-access-token")
@@ -1083,11 +1085,11 @@ class TestYNABBackend:
         mock_budget2.name = "Business Budget"
         mock_budget2.currency_format = None
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget1, mock_budget2]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget1, mock_budget2]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
         # Mock accounts
         mock_accounts_response = MagicMock()
@@ -1095,7 +1097,7 @@ class TestYNABBackend:
         mock_accounts_api = MagicMock()
         mock_accounts_api.get_accounts.return_value = mock_accounts_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
         mock_ynab_api.AccountsApi.return_value = mock_accounts_api
 
         # Login with specific budget ID
@@ -1111,13 +1113,13 @@ class TestYNABBackend:
         mock_budget.id = "budget-1"
         mock_budget.name = "Personal Budget"
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
 
         with pytest.raises(ValueError, match="Budget with ID 'invalid-id' not found"):
             await backend.login(password="test-token", budget_id="invalid-id")
@@ -1139,13 +1141,13 @@ class TestYNABBackend:
         mock_budget2.currency_format = MagicMock()
         mock_budget2.currency_format.currency_symbol = "€"
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget1, mock_budget2]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget1, mock_budget2]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
         backend.client.api_client = MagicMock()
 
         budgets = await backend.get_budgets()
@@ -1168,13 +1170,13 @@ class TestYNABBackend:
         mock_budget.last_modified_on = None
         mock_budget.currency_format = None
 
-        mock_budgets_response = MagicMock()
-        mock_budgets_response.data.budgets = [mock_budget]
+        mock_plans_response = MagicMock()
+        mock_plans_response.data.plans = [mock_budget]
 
-        mock_budgets_api = MagicMock()
-        mock_budgets_api.get_budgets.return_value = mock_budgets_response
+        mock_plans_api = MagicMock()
+        mock_plans_api.get_plans.return_value = mock_plans_response
 
-        mock_ynab_api.BudgetsApi.return_value = mock_budgets_api
+        mock_ynab_api.PlansApi.return_value = mock_plans_api
         backend.client.api_client = MagicMock()
 
         budgets = await backend.get_budgets()

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,7 @@ wheels = [
 
 [[package]]
 name = "ynab"
-version = "1.9.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2347,7 +2347,7 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/3e/36599ae876db3e1d32e393ab0934547df75bab70373c14ca5805246f99bc/ynab-1.9.0.tar.gz", hash = "sha256:fa50bdff641b3a273661e9f6e8a210f5ad98991a998dc09dec0a8122d734d1c6", size = 64898, upload-time = "2025-10-06T19:14:32.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/bf/ed29beabe8df208f7f6c6829d83b0d6fc1fb2634d1636e941bd5132dde21/ynab-4.1.0.tar.gz", hash = "sha256:9623dda46aa1c9e9e7e4ff24efe08f0041bb8dab9839fc38c76719d7c00c1125", size = 76375, upload-time = "2026-04-15T21:58:15.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/9c/0ccd11bcdf7522fcb2823fcd7ffbb48e3164d72caaf3f920c7b068347175/ynab-1.9.0-py3-none-any.whl", hash = "sha256:72ac0219605b4280149684ecd0fec3bd75d938772d65cdeea9b3e66a1b2f470d", size = 208674, upload-time = "2025-10-06T19:14:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8f/96b9f962cca0cbea056d8c0304fd0d2021fa0a42627835ed9a98bdcbab95/ynab-4.1.0-py3-none-any.whl", hash = "sha256:872a7ecf19b82ac967de86b1a71af3760b32ebec7b6bf238df8e550fa444dbfd", size = 269792, upload-time = "2026-04-15T21:58:16.998Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1061,7 +1061,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "textual", specifier = ">=0.47.0" },
-    { name = "ynab", specifier = ">=1.9.0" },
+    { name = "ynab", specifier = ">=4.1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Cherry-picks the ynab 1.9.0 → 4.1.0 bump from #97 and adapts the YNAB
client to the 4.0.0 breaking changes that the bare lockfile update
would otherwise leave broken.

The ynab SDK 4.0.0 release renamed the "Budgets" API surface to "Plans"
and switched ID fields from `str` to `uuid.UUID`. Concretely:

- `ynab.BudgetsApi` → `ynab.PlansApi`, `get_budgets()` → `get_plans()`
- All SDK methods take `plan_id=` instead of `budget_id=`
- Response data lives under `.data.plans` (not `.data.budgets`)
- `Account.id`, `Payee.id`, `Category.id`, `TransactionDetail.{account,payee,category}_id`
  are now `uuid.UUID` instead of `str`

The fixes are confined to `moneyflow/backends/ynab_client.py` and its
tests. UUIDs are stringified at the SDK boundary so the rest of
moneyflow continues to see string IDs, and string `category_id`
arguments are converted to `uuid.UUID` before being assigned to model
fields. The moneyflow-internal terminology (`self.budget_id`,
`get_budgets()`, `login(budget_id=...)`) is preserved since YNAB still
presents these to users as "budgets".

Closes #97.

## Test plan

- [x] `uv run pytest -q --no-cov` — 1411 passed
- [x] `uv run pyright moneyflow/` — 0 errors
- [x] `uv run ruff format --check moneyflow/ tests/` — clean
- [x] `uv run ruff check moneyflow/ tests/` — clean
- [ ] Smoke test against a real YNAB budget end-to-end (login, list
      transactions, edit a transaction, batch-rename a merchant)